### PR TITLE
Change IRC links into Libera.Chat

### DIFF
--- a/archive/assets/pl/Archive/src/cont/contact.developers.txt
+++ b/archive/assets/pl/Archive/src/cont/contact.developers.txt
@@ -57,7 +57,7 @@
 <h3>Kanał IRC</h3>
 
 <ul>
-<li><b>Serwer:</b> irc.freenode.net</li>
+<li><b>Serwer:</b> irc.libera.chat</li>
 <li><b>Kanał:</b> #openoffice.org-pl</li>
 <li><a href="http://pl.wikibooks.org/wiki/IRC">Polski podręcznik IRC-a</a></li>
 </ul>

--- a/archive/content/cs/Archive/mailinglist.html
+++ b/archive/content/cs/Archive/mailinglist.html
@@ -11,8 +11,8 @@
 <h4>IRC kanál</h4>
 
 <p>
-   V IRC síti <a href="http://www.freenode.net/">Freenode.net</a> byl otevřen IRC kanál <a
-   href="irc://irc.freenode.net/#cs.openoffice.org">#cs.openoffice.org</a> pro diskuse českých
+   V IRC síti <a href="http://www.libera.chat/">Libera.Chat</a> byl otevřen IRC kanál <a
+   href="ircs://irc.libera.chat/#OpenOffice.org-cs">#OpenOffice.org-cs</a> pro diskuse českých
    a slovenských uživatelů OpenOffice.org.
 </p>
 

--- a/archive/content/pl/Archive/contact.developers.html
+++ b/archive/content/pl/Archive/contact.developers.html
@@ -109,7 +109,7 @@
 <h3>Kanał IRC</h3>
 
 <ul>
-<li><b>Serwer:</b> irc.freenode.net</li>
+<li><b>Serwer:</b> irc.libera.chat</li>
 <li><b>Kanał:</b> #openoffice.org-pl</li>
 <li><a href="http://pl.wikibooks.org/wiki/IRC">Polski podręcznik IRC-a</a></li>
 </ul>

--- a/archive/content/pl/Archive/www/contact.developers.html
+++ b/archive/content/pl/Archive/www/contact.developers.html
@@ -112,7 +112,7 @@
 <h3>Kanał IRC</h3>
 
 <ul>
-<li><b>Serwer:</b> irc.freenode.net</li>
+<li><b>Serwer:</b> irc.libera.chat</li>
 <li><b>Kanał:</b> #openoffice.org-pl</li>
 <li><a href="http://pl.wikibooks.org/wiki/IRC">Polski podręcznik IRC-a</a></li>
 </ul>

--- a/content/FAQs/build_faq.html
+++ b/content/FAQs/build_faq.html
@@ -403,8 +403,8 @@ developers. IRC is not only for developers however quite a few are
 there a lot
 and can help out with quick questions and good advice.</p>
       <ul>
-        <li>server: irc.freenode.net</li>
-        <li>channel: #OpenOffice.org</li>
+        <li>server: irc.libera.chat</li>
+        <li>channel: #openoffice</li>
         <li>A quick IRC HOWTO:
           <p>first, grab yourself a client:</p>
           <p>For windows, you can use mIRC - http://www.mirc.com</p>
@@ -412,10 +412,10 @@ and can help out with quick questions and good advice.</p>
 http://www.kvirc.net</p>
           <p>then, once your client is up, you can type in the
 commandbar:</p>
-          <p>/SERVER irc.openprojects.net and after you are logged in,
+          <p>/SERVER irc.libera.chat and after you are logged in,
 you can type:</p>
           <br>
-/JOIN #OpenOffice.org
+/JOIN #openoffice
         </li>
       </ul>
       </td>

--- a/content/de/about-ooo/about-irc.html
+++ b/content/de/about-ooo/about-irc.html
@@ -37,20 +37,20 @@
               <em>
                 Englisch:
               </em>
-              <a href="irc://irc.freenode.net/OpenOffice.org">#OpenOffice.org</a>
+              <a href="ircs://irc.libera.chat/openoffice">#openoffice</a>
               </li><li>
               <em>
                 Deutsch:
               </em>
-              <a href="irc://irc.freenode.net/OpenOffice.org-de">#OpenOffice.org-de</a>
+              <a href="ircs://irc.libera.chat/openoffice.org-de">#openoffice.org-de</a>
               </li><li>Franz&ouml;sisch:
-              <a href="irc://irc.freenode.net/OpenOffice.org-fr">#OpenOffice.org-fr</a>
+              <a href="ircs://irc.libera.chat/openoffice.org-fr">#openoffice.org-fr</a>
               </li><li>Holl&auml;ndisch:
-              <a href="irc://irc.freenode.net/OpenOffice.org-nl">#OpenOffice.org-nl</a>
+              <a href="ircs://irc.libera.chat/openoffice.org-nl">#openoffice.org-nl</a>
               </li><li>Italienisch:
-              <a href="irc://irc.freenode.net/OpenOffice.org-it">#OpenOffice.org-it</a>
+              <a href="ircs://irc.libera.chat/openoffice.org-it">#openoffice.org-it</a>
               </li><li>Spanisch:
-              <a href="irc://irc.freenode.net/OpenOffice.org-es">#OpenOffice.org-es</a></li>
+              <a href="ircs://irc.libera.chat/openoffice.org-es">#openoffice.org-es</a></li>
             </ul>
             <p>
               <b>Grundeinstellungen</b>
@@ -58,9 +58,9 @@
               </p>
               <ul>
                 <li>Server:
-                <a href="irc://irc.freenode.net">irc://irc.freenode.net</a>
+                <a href="ircs://irc.libera.chat">ircs://irc.libera.chat</a>
                 </li><li>Port:
-                <a href="irc://irc.freenode.net:6667">6667</a></li>
+                <a href="ircs://irc.libera.chat:6697">6697</a></li>
               </ul>
               <p>
                 <b>Weiterf&uuml;hrende Hilfe</b>

--- a/content/de/about-ooo/about-irc.html
+++ b/content/de/about-ooo/about-irc.html
@@ -42,7 +42,7 @@
               <em>
                 Deutsch:
               </em>
-              <a href="ircs://irc.libera.chat/openoffice.org-de">#openoffice.org-de</a>
+              <a href="ircs://irc.libera.chat/openoffice.org-de">#openoffice-de</a>
               </li><li>Franz&ouml;sisch:
               <a href="ircs://irc.libera.chat/openoffice.org-fr">#openoffice.org-fr</a>
               </li><li>Holl&auml;ndisch:

--- a/content/development/index.html
+++ b/content/development/index.html
@@ -659,8 +659,8 @@ to find Contacts </td>
           <tr>
             <td colspan="4" class="tableF0">
             <ul>
-              <li>IRC (Channel: #OpenOffice.org, Server:
-irc.freenode.net)<br>
+              <li>IRC (Channel: #openoffice, Server:
+irc.libera.chat)<br>
               </li>
               <li><a href="http://projects.openoffice.org/index.html">Project
 Leads (no longer applicable, historical)</a></li>

--- a/content/development/indexNew.html
+++ b/content/development/indexNew.html
@@ -661,8 +661,8 @@ to find Contacts </td>
           <tr>
             <td colspan="4" class="tableF0">
             <ul>
-              <li>IRC (Channel: #OpenOffice.org, Server:
-irc.freenode.net)<br>
+              <li>IRC (Channel: #openoffice, Server:
+irc.libera.chat)<br>
               </li>
               <li><a href="http://projects.openoffice.org/index.html">Project
 Leads</a></li>

--- a/content/development/tryouts/index.html
+++ b/content/development/tryouts/index.html
@@ -673,8 +673,8 @@ to find Contacts </td>
           <tr>
             <td colspan="4" class="tableF0">
             <ul>
-              <li>IRC (Channel: #OpenOffice.org, Server:
-irc.freenode.net)<br>
+              <li>IRC (Channel: #openoffice, Server:
+irc.libera.chat)<br>
               </li>
               <li><a href="http://projects.openoffice.org/index.html">Project
 Leads</a></li>

--- a/content/fr/Laboratory/guide_hackers.html
+++ b/content/fr/Laboratory/guide_hackers.html
@@ -644,7 +644,7 @@ Cela semble une bonne idée de travailler sur la manière la meilleure
 pour implémenter votre fix, et/ou d'en discuter avec un ou deux
 développeurs avant tout. Une des meilleures façon est de poster sur
 dev@openoffice.apache.org (labo@fr.openoffice.org pour le français) ou de
-regarder sur IRC irc.freenode.net sur le cannal #OpenOffice.org. IRC
+regarder sur IRC irc.libera.chat sur le cannal #openoffice. IRC
 est un moyen de communication vraiment pauvre, mais mieux que pas de
 communication du tout. Voir <a
  href="http://ooo.ximian.com/name-account.html">ici</a> pour savoir qui

--- a/content/it/informazioni/irc.html
+++ b/content/it/informazioni/irc.html
@@ -12,7 +12,7 @@
 		<p>Anche it.OpenOffice.org ha il suo canale <acronym title="Internet Relay Chat">IRC</acronym>, il canale 
 			è frequentato da tutti quelli che aderiscono al progetto e lì potrai trovare aiuto. Il canale è 
 			<i>#openoffice.org-it</i> e ci si collega attraverso la rete 
-			<a href="http://freenode.net/">freenode.net</a>.</p>
+			<a href="http://libera.chat/">libera.chat</a>.</p>
 	
 		<h3>Cos'è IRC?</h3>
 
@@ -25,7 +25,7 @@
 
 		<p>Le discussioni su questa chat sono organizzate in canali, che non rappresentano
 			nient'altro che un gruppo di persone che condividono un argomento. Ogni canale è 
-			identificato da un nome che inizia con # (il nostro è <a href="irc://freenode.net/#openoffice.org-it">#openoffice.org-it</a>).</p>
+			identificato da un nome che inizia con # (il nostro è <a href="ircs://irc.libera.chat/#openoffice.org-it">#openoffice.org-it</a>).</p>
 	
 		<p>Per connettersi ad un canale è necessario avere un client <acronym title="Internet Relay Chat">IRC</acronym>
 			installato sul proprio computer. Ne esistono molti e non si fa molta fatica a trovarne uno adatto alle 
@@ -43,7 +43,7 @@
 
 <h3>Esistono regole particolari su questo canale?</h3>
 
-<p>Valgono le regole generali di buone maniere su IRC. Qui indichiamo anche i consigli dati dai gestori della rete freenode<br>
+<p>Valgono le regole generali di buone maniere su IRC. Qui indichiamo anche i consigli dati dai gestori della rete Libera Chat<br>
 
 A differenza di quanto accade con la comunicazione faccia a faccia, IRC
 non permette agli interlocutori di comunicare attraverso il corpo, il

--- a/content/porting/freebsd/index.html
+++ b/content/porting/freebsd/index.html
@@ -419,7 +419,7 @@ See the diff.
 <li> <a href="http://wiki.services.openoffice.org/wiki/OOoRelease32">OOo Release 3.2 Wiki</a>
 <li> <a href="http://wiki.services.openoffice.org/wiki/OOoRelease33">OOo Release 3.3 Wiki</a>
 <li> <a href="http://tools.openoffice.org/dev_docs/OOo_cws.html">CWS howto</a>
-<li> <a href="irc://irc.freenode.net/#OpenOffice.org">IRC@Freenode.net, #OpenOffice.org</a>
+<li> <a href="ircs://irc.libera.chat/#openoffice">IRC@libera.chat, #openoffice</a>
 <li> <a href="http://wiki.services.openoffice.org/wiki/Languages">Supported langs. lang codes, etc. </a>
 <li> <a href="http://www.catch.jp/openoffice/#clipart">A picture of BSD Daemon</a>
 </ul>

--- a/content/porting/mac/faq/contact/index.html
+++ b/content/porting/mac/faq/contact/index.html
@@ -34,7 +34,7 @@
 <h4>Contact the Mac Porting Team</h4>
 
 <p>Send a mail to <a href="mailto:mac@porting.openoffice.org">mac@porting.openoffice.org</a></p>
-<p>Join us on IRC: server: <a href="irc://irc.freenode.net/ooo_macport">irc.freenode.net, channel: #ooo_macport</a></p> 
+<p>Join us on IRC: server: <a href="ircs://irc.libera.chat/openoffice">irc.libera.chat, channel: #openoffice</a></p>
     <div id="bcorner1"></div>
 </div>
 

--- a/content/qa/wwwstaging/tasks/quickstart.html
+++ b/content/qa/wwwstaging/tasks/quickstart.html
@@ -147,7 +147,7 @@
 <p><br>
 
 <h2>What makes a good or bad bug report?</h2>
-<p>It can be daunting at first when trying to figure out what is a good bug report and what is a bad bug report. The mailing list and IRC ( channel #qa.openoffice.org at irc.freenode.net ) is a good place to get help from other members of the team.
+<p>It can be daunting at first when trying to figure out what is a good bug report and what is a bad bug report. The mailing list and IRC ( channel #openoffice at irc.libera.chat ) is a good place to get help from other members of the team.
 
 <p>The key rule to remember is:
 <p style="margin-left: 10%;margin-right: 15%;background: #fff600;padding: 15px;">A clear list of steps to reproduce the bug on any system.

--- a/content/tools/dev_docs/howtocontribute.html
+++ b/content/tools/dev_docs/howtocontribute.html
@@ -79,7 +79,7 @@ different dev@*.openoffice.org lists. Here you are able to discuss
 with the developers about problems and enhancements. You also can use
 IssueZilla, the OpenOffice.org Bug Tracking System to file your
 problems or feature requests into the Database. (see also
-irc://freenode/openoffice.org  for on line discussions)</P>
+ircs://irc.libera.chat/openoffice for on line discussions)</P>
 <H3 CLASS="western">OpenOffice.org Quality Assurance</H3>
 <P>If you are interested on being on the bleeding edge it might be
 useful to join the QA Team (<A HREF="mailto:qa@openoffice.apache.org">qa@openoffice.apache.org</A>).
@@ -87,7 +87,7 @@ There are several interesting projects like automatic GUI testing
 (<A HREF="http://qa.openoffice.org/qatesttool">http://qa.openoffice.org/qatesttool</A>)
 and OOo API testing (<A HREF="http://qa.openoffice.org/qadevOOo">http://qa.openoffice.org/qadevOOo</A>)
 as well as the daily QA work (see also
-irc://freenode/qa.openoffice.org )</P>
+ircs://irc.libera.chat/openoffice )</P>
 <H3 CLASS="western">OpenOffice.org Content Developer</H3>
 <P>In the OpenOffice.org Project there are not only things to do
 directly related to the Product but there is also a lot of other work


### PR DESCRIPTION
The purpose of this PR is to update the project's contact information with respect to the IRC network.

It does not involve all the occurrences of the "Freenode" word because some documents, IMHO, should keep the original links for historical purposes.

I am also not sure that all the pages edited here are still worth being kept online.