### PR TITLE
Drop Adfinis SyGroup from consultants.xml

### DIFF
--- a/assets/bizdev/consultants/consultants.xml
+++ b/assets/bizdev/consultants/consultants.xml
@@ -2,24 +2,6 @@
 <consultants>
 
     <consultant>
-        <name>Adfinis SyGroup AG</name>
-        <country>CH</country>
-        <practice>Development</practice>
-        <practice>Support</practice>
-        <practice>Other</practice>
-        <description>
-            Adfinis SyGroup AG has been active in the open source environment
-            for more than a decade. We provide services such as development,
-            maintenance and operation based on open source technologies,
-            including OpenOffice. With offices in Basel and Bern, we support
-            customers throughout Switzerland and neighbouring countries.
-        </description>
-        <website>https://adfinis-sygroup.ch/openoffice_support_and_development</website>
-        <email>david.vogt@adfinis-sygroup.ch</email>
-        <phone>+41 31 550 31 11</phone>
-    </consultant>
-
-    <consultant>
         <name>Özgür Yazılım A.Ş.</name>
         <country>TR</country>
         <practice>Training</practice>


### PR DESCRIPTION
Adfinis SyGroup is not providing AOO consultant services to new clients anymore, and therefore request to be removed from the public consultants list.